### PR TITLE
Fix API delete issue

### DIFF
--- a/app/api/todos/$id/delete.mjs
+++ b/app/api/todos/$id/delete.mjs
@@ -12,10 +12,10 @@ export async function post (req) {
   // eslint-disable-next-line no-unused-vars
   let { problems: removedProblems, todo: removed, ...newSession } = session
   try {
-    await deleteTodo(id)
+    let result = await deleteTodo(id)
     return {
       session: newSession,
-      json: null,
+      json: { result },
       location: '/todos'
     }
   }

--- a/app/browser/worker.mjs
+++ b/app/browser/worker.mjs
@@ -59,8 +59,9 @@ async function stateMachine ({ data }) {
     break
   case DESTROY:
     try {
+      const key = JSON.parse(payload).key
       const result = await (await fetch(
-        `/todos/delete`, {
+        `/todos/${key}/delete`, {
           body: payload,
           credentials: 'same-origin',
           headers: {


### PR DESCRIPTION
I've propagated the fix to `app/api/todos/$id/delete.mjs` into the CLI.

The other fix was calling `/todos/$id/delete` instead of `/todos/delete`. 

Signed-off-by: macdonst <simon.macdonald@gmail.com>